### PR TITLE
Add type conversion for port

### DIFF
--- a/kule/kule.py
+++ b/kule/kule.py
@@ -185,7 +185,7 @@ def main():
     parser.add_option("--mongodb-host", dest="mongodb_host",
                       help="MongoDB host")
     parser.add_option("--mongodb-port", dest="mongodb_port",
-                      help="MongoDB port")
+                      type="int", help="MongoDB port")
     parser.add_option("-d", "--database", dest="database",
                       help="MongoDB database name")
     parser.add_option("-c", "--collections", dest="collections",


### PR DESCRIPTION
This change forces OptionParser to automatically typecast the MongoDB port to an integer, preventing the message mentioned in Issue #6.
